### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A lightweight MCP server that tells you exactly who you are.
 
+<a href="https://glama.ai/mcp/servers/@kukapay/whoami-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/whoami-mcp/badge" alt="whoami-mcp MCP server" />
+</a>
+
 ![GitHub License](https://img.shields.io/github/license/kukapay/whoami-mcp) 
 ![GitHub Last Commit](https://img.shields.io/github/last-commit/kukapay/whoami-mcp) 
 ![Python Version](https://img.shields.io/badge/python-3.10%2B-blue)


### PR DESCRIPTION
This PR adds a badge for the [whoami-mcp](https://glama.ai/mcp/servers/@kukapay/whoami-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kukapay/whoami-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/whoami-mcp/badge" alt="whoami-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.